### PR TITLE
Don't send an empty set of metrics to OpenTSDB. Even though it is perfec...

### DIFF
--- a/src/main/java/com/github/sps/metrics/OpenTsdbReporter.java
+++ b/src/main/java/com/github/sps/metrics/OpenTsdbReporter.java
@@ -211,6 +211,9 @@ public class OpenTsdbReporter extends ScheduledReporter {
         final Set<OpenTsdbMetric> metrics = new HashSet<OpenTsdbMetric>();
 
         for (Map.Entry<String, Gauge> g : gauges.entrySet()) {
+            if(g.getValue().getValue() instanceof Collection && ((Collection)g.getValue().getValue()).isEmpty()) {
+                continue;
+            }
             metrics.add(buildGauge(g.getKey(), g.getValue(), timestamp));
         }
 

--- a/src/test/java/com/github/sps/metrics/OpenTsdbReporterTest.java
+++ b/src/test/java/com/github/sps/metrics/OpenTsdbReporterTest.java
@@ -249,6 +249,24 @@ public class OpenTsdbReporterTest {
         assertEquals((Double) meterMap.get("prefix.meter.m15"), 4.0, 0.0001);
     }
 
+    /**
+     * This tests that empty metrics sets will not be sent to the OpenTSDB server which
+     * (at the time of authoring this test) fails to parse the JSON even though it is perfectly valid.
+     * it is a particular problem with dropwizard's jvm.threads.deadlocks metric which contains an empty Set<String>
+     * under normal operating conditions (i.e.: no deadlocks)
+     */
+    @Test
+    public void testEmptyGaugeSet() {
+        final Gauge gauge = mock(Gauge.class);
+        when(gauge.getValue()).thenReturn(new HashSet<String>());
+        reporter.report(this.map("gauge", gauge), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+
+        verify(opentsdb).send(captor.capture());
+
+        final Set<OpenTsdbMetric> metrics = captor.getValue();
+        assertEquals(0, metrics.size());
+    }
+
     private <T> SortedMap<String, T> map() {
         return new TreeMap<String, T>();
     }


### PR DESCRIPTION
...tly valid JSON, it fails to parse an empty list. This is a problem with Dropwizard's jvm.threads.deadlocks metric which is empty under normal operating conditions.

It's a tough call on whether this is an actual bug in OpenTSDB but It looks like they are intentionally throwing the BadRequestException when content is empty (parsePutV1 explicitly states it will throw on empty content in the JavaDoc)

$ curl 'http://localhost:4242/api/put' -d '{"metric":"my-app.jvm.threads.deadlocks","timestamp":1409092196,"value":[],"tags":{"type":"app"}}'
{"error":{"code":400,"message":"Unable to parse the given JSON","details":"com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.String out of START_ARRAY token\n at [Source: java.io.StringReader@4ced1dfe; line: 1, column: 84](through reference chain: net.opentsdb.core.IncomingDataPoint["value"])","trace":"net.opentsdb.tsd.BadRequestException: Unable to parse the given JSON\n\tat net.opentsdb.tsd.HttpJsonSerializer.parsePutV1(HttpJsonSerializer.java:143)
....
....

I feel like OpenTSDB should handle this situation more gracefully than throwing an exception but I'm not comfortable enough with their codebase or philosophy to start that discussion with them yet and for now, it seems more efficient to not send an empty metric than to send more data on the wire.
