### PR TITLE
Moved to Jersey Client 2.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <metrics.version>3.0.2</metrics.version>
-        <jersey.version>1.18.3</jersey.version>
+        <jersey.version>2.17</jersey.version>
         <mockito.version>1.10.17</mockito.version>
         <slf4j.version>1.7.5</slf4j.version>
         <junit.version>4.12</junit.version>
@@ -57,33 +57,28 @@
     </issueManagement>
 
     <dependencies>
-
         <dependency>
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${metrics.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${jersey.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-json</artifactId>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
             <version>${jersey.version}</version>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -96,7 +91,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
@@ -116,7 +110,6 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -126,7 +119,7 @@
                         <id>enforce</id>
                         <configuration>
                             <rules>
-                                <DependencyConvergence />
+                                 <requireUpperBoundDeps />
                             </rules>
                         </configuration>
                         <goals>
@@ -135,7 +128,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -149,7 +141,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -163,7 +154,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
@@ -181,8 +171,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -225,7 +213,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
@@ -234,17 +221,13 @@
                     <repoToken>${COVERALLS_REPO_TOKEN}</repoToken>
                 </configuration>
             </plugin>
-
-
         </plugins>
     </build>
 
     <profiles>
         <profile>
             <id>release</id>
-            <build>
-
-            </build>
+            <build></build>
         </profile>
     </profiles>
 

--- a/src/test/java/com/github/sps/metrics/opentsdb/OpenTsdbTest.java
+++ b/src/test/java/com/github/sps/metrics/opentsdb/OpenTsdbTest.java
@@ -15,20 +15,21 @@
  */
 package com.github.sps.metrics.opentsdb;
 
-import com.sun.jersey.api.client.WebResource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import javax.ws.rs.core.MediaType;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.*;
 
 /**
@@ -40,10 +41,10 @@ public class OpenTsdbTest {
     private OpenTsdb openTsdb;
 
     @Mock
-    private WebResource apiResource;
+    private WebTarget apiResource;
 
     @Mock
-    WebResource.Builder mockBuilder;
+    Invocation.Builder mockBuilder;
 
     @Before
     public void setUp() {
@@ -54,28 +55,28 @@ public class OpenTsdbTest {
     @Test
     public void testSend() {
         when(apiResource.path("/api/put")).thenReturn(apiResource);
-        when(apiResource.type(MediaType.APPLICATION_JSON)).thenReturn(mockBuilder);
-        when(mockBuilder.entity(anyObject())).thenReturn(mockBuilder);
+        when(apiResource.request()).thenReturn(mockBuilder);
+        when(mockBuilder.post((Entity<?>) anyObject())).thenReturn(mock(Response.class));
         openTsdb.send(OpenTsdbMetric.named("foo").build());
-        verify(mockBuilder).post();
+        verify(mockBuilder).post((Entity<?>) anyObject());
     }
 
     @Test
     public void testSendMultiple() {
         when(apiResource.path("/api/put")).thenReturn(apiResource);
-        when(apiResource.type(MediaType.APPLICATION_JSON)).thenReturn(mockBuilder);
-        when(mockBuilder.entity(anyObject())).thenReturn(mockBuilder);
+        when(apiResource.request()).thenReturn(mockBuilder);
+        when(mockBuilder.post((Entity<?>) anyObject())).thenReturn(mock(Response.class));
 
         Set<OpenTsdbMetric> metrics = new HashSet<OpenTsdbMetric>(Arrays.asList(OpenTsdbMetric.named("foo").build()));
         openTsdb.send(metrics);
-        verify(mockBuilder, times(1)).post();
+        verify(mockBuilder, times(1)).post((Entity<?>) anyObject());
 
         // split into two request
         for (int i = 1; i < 20; i++) {
             metrics.add(OpenTsdbMetric.named("foo" + i).build());
         }
         openTsdb.send(metrics);
-        verify(mockBuilder, times(3)).post();
+        verify(mockBuilder, times(3)).post((Entity<?>) anyObject());
     }
 
     @Test


### PR DESCRIPTION
I had a problem with the following exception:
```
com.sun.jersey.api.client.ClientHandlerException: com.sun.jersey.api.client.ClientHandlerException: A message body writer for Java type, class java.util.Collections$SingletonSet, and MIME media type, application/json, was not found
```
which I couldn't fix, so I decided to try to upgrade Jersey Client up to 2.17. And it helped! I tested the code locally with my OpenTSDB instance.