### PR TITLE
Telnet-style reporter and per-metric tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ Metrics OpenTSDB  [![Build Status](https://travis-ci.org/sps/metrics-opentsdb.pn
 A Coda Hale [Metrics](http://metrics.codahale.com/) Reporter.
 
 OpenTsdbReporter allows your application to constantly stream metric values to an opentsdb server
-via the [2.0 HTTP API](http://opentsdb.net/docs/build/html/api_http/index.html).
+via the [2.0 HTTP API](http://opentsdb.net/docs/build/html/api_http/index.html) or the
+[Telnet API](http://opentsdb.net/docs/build/html/user_guide/writing.html#telnet).
+
+This reporter also supports per-metric tags in addition to a global set of tags.
 
 Example Usage
 -------------
@@ -21,4 +24,12 @@ Example Usage
           .start(30L, TimeUnit.SECONDS);
 
 
+The Telnet API is identical to the above, except with
 
+    OpenTsdbTelnet.forService("mycollector.example.com", 4243)
+
+
+For per-metric tags, encode the tags into the metric name using
+
+    Map<String, String> myCounterTags;
+    String name = OpenTsdbMetric.encodeTagsInName('mycounter', myCounterTags);

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.github.sps.metrics</groupId>
     <artifactId>metrics-opentsdb</artifactId>
-    <version>1.1.0-AL-SNAPSHOT</version>
+    <version>1.1.0-Turn</version>
     <packaging>jar</packaging>
 
     <name>metrics-opentsdb</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.github.sps.metrics</groupId>
     <artifactId>metrics-opentsdb</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.1.0-AL-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>metrics-opentsdb</name>

--- a/src/main/java/com/github/sps/metrics/opentsdb/OpenTsdb.java
+++ b/src/main/java/com/github/sps/metrics/opentsdb/OpenTsdb.java
@@ -29,9 +29,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * OpenTSDB 2.0 jersey based REST client
- * <p/>
- * {@link http://opentsdb.net/docs/build/html/api_http/index.html#version-1-x-to-2-x}
+ * OpenTSDB 2.0 jersey based REST client.
+ *
+ * {@link <a href="http://opentsdb.net/docs/build/html/api_http/index.html#version-1-x-to-2-x">HTTP API</a>}
  *
  * @author Sean Scanlon <sean.scanlon@gmail.com>
  */
@@ -46,7 +46,7 @@ public class OpenTsdb {
      * Initiate a client Builder with the provided base opentsdb server url.
      *
      * @param baseUrl
-     * @return
+     * @return a {@link Builder}
      */
     public static Builder forService(String baseUrl) {
         return new Builder(baseUrl);
@@ -87,6 +87,13 @@ public class OpenTsdb {
             return new OpenTsdb(baseUrl, connectionTimeout, readTimeout);
         }
     }
+
+	/**
+	 * For OpenTsdbTelnet
+	 */
+	protected OpenTsdb() {
+		this.apiResource = null;
+	}
 
     private OpenTsdb(WebResource apiResource) {
         this.apiResource = apiResource;

--- a/src/main/java/com/github/sps/metrics/opentsdb/OpenTsdbMetric.java
+++ b/src/main/java/com/github/sps/metrics/opentsdb/OpenTsdbMetric.java
@@ -18,20 +18,171 @@ package com.github.sps.metrics.opentsdb;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
+import java.util.Scanner;
+import java.lang.IllegalArgumentException;
+import java.util.NoSuchElementException;
 
 /**
+ * Representation of a metric.
+ *
  * @author Sean Scanlon <sean.scanlon@gmail.com>
- *         <p/>
- *         Representation of a metric.
+ * @author Adam Lugowski <adam.lugowski@turn.com>
+ *
  */
 public class OpenTsdbMetric {
 
     private OpenTsdbMetric() {
     }
 
+    /**
+     * Convert a tag string into a tag map.
+     *
+     * @param tagString a space-delimited string of key-value pairs. For example, {@code "key1=value1 key_n=value_n"}
+     * @return a tag {@link Map}
+     * @throws IllegalArgumentException if the tag string is corrupted.
+     */
+    public static Map<String, String> parseTags(final String tagString) throws IllegalArgumentException {
+        // delimit by whitespace or '='
+        Scanner scanner = new Scanner(tagString).useDelimiter("\\s+|=");
+
+        Map<String, String> tagMap = new HashMap<String, String>();
+        try {
+            while (scanner.hasNext()) {
+                String tagName = scanner.next();
+                String tagValue = scanner.next();
+                tagMap.put(tagName, tagValue);
+            }
+        } catch (NoSuchElementException e) {
+            // The tag string is corrupted.
+            throw new IllegalArgumentException("Invalid tag string '" + tagString + "'");
+        } finally {
+            scanner.close();
+        }
+
+        return tagMap;
+    }
+
+    /**
+     * Convert a tag map into a space-delimited string.
+     *
+     * @param tagMap
+     * @return a space-delimited string of key-value pairs. For example, {@code "key1=value1 key_n=value_n"}
+     */
+    public static String formatTags(final Map<String, String> tagMap) {
+        StringBuilder stringBuilder = new StringBuilder();
+        String delimeter = "";
+
+        for (Map.Entry<String, String> tag : tagMap.entrySet()) {
+            stringBuilder.append(delimeter)
+                    .append(sanitize(tag.getKey()))
+                    .append("=")
+                    .append(sanitize(tag.getValue()));
+            delimeter = " ";
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Add TSDB tags to a CodaHale metric name.
+     *
+     * A CodaHale metric name is a single string, so there is no natural way to encode TSDB tags.
+     * This function formats the tags into the metric name so they can later be parsed by the
+     * Builder. The name is formatted such that it can be appended to create sub-metric names, as
+     * happens with Meter and Histogram.
+     *
+     * @param name CodaHale metric name
+     * @param tags A space-delimited string of TSDB key-value pair tags
+     * @return A metric name encoded with tags.
+     * @throws IllegalArgumentException if the tag string is invalid
+     */
+    public static String encodeTagsInName(final String name, final String tags) throws IllegalArgumentException {
+        return encodeTagsInName(name, parseTags(tags));
+    }
+
+    /**
+     * Add TSDB tags to a CodaHale metric name.
+     *
+     * A CodaHale metric name is a single string, so there is no natural way to encode TSDB tags.
+     * This function formats the tags into the metric name so they can later be parsed by the
+     * Builder. The name is formatted such that it can be appended to create sub-metric names, as
+     * happens with Meter and Histogram.
+     *
+     * @param name CodaHale metric name
+     * @param tags a {@link Map} of TSDB tags
+     * @return A metric name encoded with tags.
+     */
+    public static String encodeTagsInName(final String name, final Map<String, String> tags) {
+        return String.format("TAG(%s)%s", formatTags(tags), sanitize(name));
+    }
+
+    /**
+     * Tests whether a name has been processed with {@code encodeTagsInName}.
+     *
+     * @param name a metric name
+     * @return {@code true} if {@code name} has tags encoded, {@code false} otherwise.
+     */
+    public static boolean hasEncodedTagInName(final String name) {
+        if (name == null)
+            return false;
+
+        return name.startsWith("TAG(");
+    }
+
+    /**
+     * Call this function whenever a potentially tag-encoded name is prefixed.
+     *
+     * @param name a metric name with encoded tag strings that has been prefixed.
+     * @return a fixed metric name
+     */
+    public static String fixEncodedTagsInNameAfterPrefix(final String name) {
+        if (name == null)
+            return name;
+
+        int tagStart = name.indexOf("TAG(");
+
+        if (tagStart == -1)
+            return name; // no tags in this name
+
+        if (tagStart == 0)
+            return name; // tag string is already correct
+
+        // extract the "TAG(...)" string from the middle of the name and put it at the front.
+        int tagEnd = name.lastIndexOf(')');
+        if (tagEnd == -1) {
+            throw new IllegalArgumentException("Tag definition missing closing parenthesis for metric '" + name + "'");
+        }
+
+        String tagString = name.substring(tagStart, tagEnd+1);
+        return tagString + name.substring(0, tagStart) + name.substring(tagEnd+1);
+    }
+
+    /**
+     * Creates a Builder for a metric name.
+     *
+     * @param name name can contain either a pure CodaHale metric name, or a string returned by {@code encodeTagsInName}.
+     *             If it's the latter, the tags are parsed out and passed to {@code withTags}.
+     * @return a {@link Builder}
+     */
     public static Builder named(String name) {
-        return new Builder(name);
+		/*
+		A name can contain either a pure metric name, or a string returned by encodeTagsInName().
+		If it's the latter, it looks like "TAG(tag1=value1 tag2=value2)metricname".
+		 */
+		if (!hasEncodedTagInName(name)) {
+            return new Builder(name);
+        }
+
+        // parse out the tags
+        int tagEnd = name.lastIndexOf(')');
+        if (tagEnd == -1) {
+            throw new IllegalArgumentException("Tag definition missing closing parenthesis for metric '" + name + "'");
+        }
+
+        String tagString = name.substring(4, tagEnd);
+        name = name.substring(tagEnd+1);
+
+        return new Builder(name).withTags(parseTags(tagString));
     }
 
     private String metric;
@@ -98,6 +249,23 @@ public class OpenTsdbMetric {
     }
 
 
+    /**
+     * Returns a JSON string version of this metric compatible with the HTTP API reporter.
+     *
+     * Example:
+     * <pre><code>
+     * {
+     *     "metric": "sys.cpu.nice",
+     *     "timestamp": 1346846400,
+     *     "value": 18,
+     *     "tags": {
+     *         "host": "web01",
+     *         "dc": "lga"
+     *     }
+     * }
+     * </code></pre>
+     * @return a JSON string version of this metric compatible with the HTTP API reporter.
+     */
     @Override
     public String toString() {
         return this.getClass().getSimpleName()
@@ -106,6 +274,39 @@ public class OpenTsdbMetric {
                 + ",timestamp: " + timestamp
                 + ",tags: " + tags;
     }
+
+    /**
+     * Sanitizes a metric name, tag key, or tag value by removing characters not allowed by TSDB.
+     *
+     * Supported characters are {@code a-z A-Z 0-9 - _ . / }
+     *
+     * @param name a metric name, tag key, or tag value
+     * @return {@code name} where unsupported characters are replaced with {@code "-"}.
+     */
+	public static String sanitize(String name) {
+		return name.replaceAll("[^a-zA-Z0-9\\-\\_\\.\\/]", "-");
+	}
+
+    /**
+     * Returns a put string version of this metric compatible with the telnet-style reporter.
+     *
+     * Format:
+     * <pre><code>
+     * put (metric-name) (timestamp) (value) (tags)
+     * </code></pre>
+     *
+     * Example:
+     * <pre><code>
+     * put sys.cpu.nice 1346846400 18 host=web01 dc=lga
+     * </code></pre>
+     *
+     * @return a string version of this metric compatible with the telnet reporter.
+     */
+	public String toTelnetPutString() {
+		String tagString = formatTags(tags);
+
+		return String.format("put %s %d %s %s\n", metric, timestamp, value, tagString);
+	}
 
     public String getMetric() {
         return metric;
@@ -127,15 +328,3 @@ public class OpenTsdbMetric {
         return (a == b) || (a != null && a.equals(b));
     }
 }
-
-/*
-{
-    "metric": "sys.cpu.nice",
-    "timestamp": 1346846400,
-    "value": 18,
-    "tags": {
-       "host": "web01",
-       "dc": "lga"
-    }
-}
- */

--- a/src/main/java/com/github/sps/metrics/opentsdb/OpenTsdbTelnet.java
+++ b/src/main/java/com/github/sps/metrics/opentsdb/OpenTsdbTelnet.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.sps.metrics.opentsdb;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Same as the {@link OpenTsdb} class in this package, but uses the
+ * {@link <a href="http://opentsdb.net/docs/build/html/user_guide/writing.html#telnet">Telnet</a>}
+ * format.
+ *
+ * This class can write to a {@link Socket} or a {@link Writer}.
+ *
+ * @author Adam Lugowski <adam.lugowski@turn.com>
+ */
+public class OpenTsdbTelnet extends OpenTsdb {
+	private static final Logger logger = LoggerFactory.getLogger(OpenTsdbTelnet.class);
+
+	protected interface WriterFactory {
+		Writer getWriter() throws java.io.IOException;
+	}
+
+	protected static class SingleWriterFactory implements WriterFactory {
+		private Writer writer;
+
+		public SingleWriterFactory(Writer writer) {
+			this.writer = writer;
+		}
+
+		@Override
+		public Writer getWriter() {
+			return writer;
+		}
+	}
+
+	protected static class SocketWriterFactory implements WriterFactory {
+		private String host = null;
+		private int port = -1;
+
+		public SocketWriterFactory(String host, int port) {
+			this.host = host;
+			this.port = port;
+		}
+
+		@Override
+		public Writer getWriter() throws java.io.IOException {
+			Socket socket = new Socket(host, port, null, 0);
+			Writer socketWriter = new OutputStreamWriter(socket.getOutputStream());
+			return new BufferedWriter(socketWriter);
+		}
+	}
+
+	/**
+	 * Initiate a client {@link Builder} with the provided opentsdb server {@code host:port}.
+	 *
+	 * @param host is the hostname of the opentsdb server
+	 * @param port is the port
+	 * @return a {@link Builder}
+	 */
+	public static Builder forService(String host, int port) {
+		return new Builder(new SocketWriterFactory(host, port));
+	}
+
+	/**
+	 * Initiate a client {@link Builder} with a particular {@link Writer}.
+	 *
+	 * @param writer {@link Writer} to write metrics to. Will be closed when done.
+	 * @return a {@link Builder}
+	 */
+	public static Builder forWriter(Writer writer) {
+		return new Builder(new SingleWriterFactory(writer));
+	}
+
+	private WriterFactory writerFactory;
+
+	public static class Builder {
+		private WriterFactory writerFactory;
+
+		private Builder(WriterFactory writerFactory) {
+			this.writerFactory = writerFactory;
+		}
+
+		public OpenTsdbTelnet create() {
+			return new OpenTsdbTelnet(writerFactory);
+		}
+	}
+
+	private OpenTsdbTelnet(WriterFactory writerFactory) {
+		this.writerFactory = writerFactory;
+	}
+
+	/**
+	 * Send a metric to opentsdb
+	 *
+	 * @param metric
+	 */
+	@Override
+	public void send(OpenTsdbMetric metric) {
+		send(Collections.singleton(metric));
+	}
+
+	/**
+	 * send a set of metrics to opentsdb
+	 *
+	 * @param metrics
+	 */
+	@Override
+	public void send(Set<OpenTsdbMetric> metrics) {
+		if (metrics.isEmpty())
+			return;
+
+		Writer writer = null;
+		try {
+			writer = this.writerFactory.getWriter();
+			write(metrics, writer);
+		} catch (Exception e) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Error writing codahale metrics", e);
+			} else {
+				logger.warn("Error writing codahale metrics: {}", e.getMessage());
+			}
+		} finally {
+			if (writer != null) {
+				try {
+					writer.close();
+				} catch (IOException e) {
+					logger.error("Error while closing writer:", e);
+				}
+			}
+		}
+	}
+
+	public void write(Set<OpenTsdbMetric> metrics, Writer writer) throws IOException {
+		for (final OpenTsdbMetric metric : metrics) {
+			writer.write(metric.toTelnetPutString());
+		}
+	}
+}

--- a/src/test/java/com/github/sps/metrics/OpenTsdbReporterTest.java
+++ b/src/test/java/com/github/sps/metrics/OpenTsdbReporterTest.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 /**
@@ -266,6 +267,31 @@ public class OpenTsdbReporterTest {
         final Set<OpenTsdbMetric> metrics = captor.getValue();
         assertEquals(0, metrics.size());
     }
+
+    @Test
+    public void testPerMetricTags() {
+
+        when(counter.getCount()).thenReturn(2L);
+        String encodedName = OpenTsdbMetric.encodeTagsInName("counter", Collections.singletonMap("foo2", "bar2"));
+        reporter.report(this.<Gauge>map(), this.map(encodedName, counter), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        verify(opentsdb).send(captor.capture());
+
+        final Set<OpenTsdbMetric> metrics = captor.getValue();
+        assertEquals(1, metrics.size());
+        OpenTsdbMetric metric = metrics.iterator().next();
+        assertEquals("prefix.counter.count", metric.getMetric());
+        assertEquals((Long) timestamp, metric.getTimestamp());
+        assertEquals(2L, metric.getValue());
+
+        Map<String,String> tags = metric.getTags();
+        assertEquals(2, tags.size());
+        assertTrue(tags.containsKey("foo")); // applied to all metrics
+        assertEquals("bar", tags.get("foo"));
+        assertTrue(tags.containsKey("foo2")); // applied to just this counter
+        assertEquals("bar2", tags.get("foo2"));
+    }
+
+
 
     private <T> SortedMap<String, T> map() {
         return new TreeMap<String, T>();

--- a/src/test/java/com/github/sps/metrics/opentsdb/OpenTsdbMetricTest.java
+++ b/src/test/java/com/github/sps/metrics/opentsdb/OpenTsdbMetricTest.java
@@ -18,6 +18,7 @@ package com.github.sps.metrics.opentsdb;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -60,5 +61,64 @@ public class OpenTsdbMetricTest {
 
         assertNotNull(o1.toString());
 
+    }
+
+    @Test
+    public void testTagsInNameEncode() {
+        String encoded = OpenTsdbMetric.encodeTagsInName("counter", "foo=bar");
+
+        assertTrue(OpenTsdbMetric.hasEncodedTagInName(encoded));
+        assertFalse(OpenTsdbMetric.hasEncodedTagInName("counter"));
+
+        String prefixed = "prefix."+encoded;
+        String fixedPrefixed = OpenTsdbMetric.fixEncodedTagsInNameAfterPrefix(prefixed);
+
+        assertTrue(OpenTsdbMetric.hasEncodedTagInName(fixedPrefixed));
+
+        String appended = encoded+".app";
+        assertTrue(OpenTsdbMetric.hasEncodedTagInName(appended));
+    }
+
+    @Test
+    public void testTags() {
+        OpenTsdbMetric o1 = OpenTsdbMetric.named(OpenTsdbMetric.encodeTagsInName("counter", "foo=bar"))
+                .withValue(1L)
+                .withTimestamp(null)
+                .withTags(null)
+                .build();
+
+        assertTrue(o1.equals(o1));
+
+        assertEquals("counter", o1.getMetric().toString());
+
+        Map<String,String> tags = o1.getTags();
+        assertEquals(1, tags.size());
+        assertTrue(tags.containsKey("foo"));
+        assertEquals("bar", tags.get("foo"));
+    }
+
+    @Test
+    public void testTelnetString() {
+        OpenTsdbMetric o1 = OpenTsdbMetric.named(OpenTsdbMetric.encodeTagsInName("counter", "foo=bar"))
+                .withValue(1L)
+                .withTimestamp(Long.valueOf(123))
+                .build();
+
+        String telnetString = o1.toTelnetPutString();
+        assertEquals("put counter 123 1 foo=bar\n", telnetString);
+    }
+
+    @Test
+    public void testSanitize() {
+
+        assertEquals("foo_---", OpenTsdbMetric.sanitize("foo_*&^"));
+
+        OpenTsdbMetric o1 = OpenTsdbMetric.named(OpenTsdbMetric.encodeTagsInName("counter!@#", "^&*foo=bar()&"))
+                .withValue(1L)
+                .withTimestamp(Long.valueOf(123))
+                .build();
+
+        String telnetString = o1.toTelnetPutString();
+        assertEquals("put counter--- 123 1 ---foo=bar---\n", telnetString);
     }
 }

--- a/src/test/java/com/github/sps/metrics/opentsdb/OpenTsdbTelnetTest.java
+++ b/src/test/java/com/github/sps/metrics/opentsdb/OpenTsdbTelnetTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.sps.metrics.opentsdb;
+
+import com.sun.jersey.api.client.WebResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.MediaType;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Adam Lugowski <adam.lugowski@turn.com>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OpenTsdbTelnetTest {
+
+	private OpenTsdbTelnet openTsdb;
+
+	private StringWriter writer;
+
+	@Before
+	public void setUp() {
+		writer = new StringWriter();
+		openTsdb = OpenTsdbTelnet.forWriter(writer).create();
+	}
+
+	@Test
+	public void testSend() {
+		OpenTsdbMetric o1 = OpenTsdbMetric.named(OpenTsdbMetric.encodeTagsInName("counter", "foo=bar"))
+				.withValue(1L)
+				.withTimestamp(Long.valueOf(123))
+				.build();
+
+		openTsdb.send(o1);
+
+		String telnetString = writer.toString();
+		assertEquals("put counter 123 1 foo=bar\n", telnetString);
+
+	}
+
+	@Test
+	public void testSendMultiple() {
+		Set<OpenTsdbMetric> metrics = new HashSet<OpenTsdbMetric>();
+
+		for (int i = 0; i < 10; i++) {
+			OpenTsdbMetric o1 = OpenTsdbMetric.named(OpenTsdbMetric.encodeTagsInName("counter", "foo=bar"+i))
+					.withValue(1L)
+					.withTimestamp(Long.valueOf(123))
+					.build();
+
+			metrics.add(o1);
+		}
+		openTsdb.send(metrics);
+
+		// verify output
+		String telnetString = writer.toString();
+		String[] lines = telnetString.split("\n");
+
+		Arrays.sort(lines); // necessary because a HashSet doesn't guarantee an iteration order
+
+		assertEquals(10, lines.length);
+		for (int i = 0; i < 10; i++) {
+			assertEquals("put counter 123 1 foo=bar" + i, lines[i]);
+		}
+	}
+
+	@Test
+	public void testBuilder() {
+		assertNotNull(OpenTsdbTelnet.forService("localhost", 123)
+				.create());
+
+		assertNotNull(OpenTsdbTelnet.forWriter(new StringWriter())
+				.create());
+	}
+
+}


### PR DESCRIPTION
I'm asending our internal changes to your reporter upstream. Our pipeline requires the older Telnet-style reporter, and we felt others might as well. Also, TSDB supports per-metric tags, something that seems to be missing from every CodaHale metrics reporter I've found. While there's no clean solution to this problem due to the limitations of CH Metrics' naming scheme, the approach we introduced in this PR works well for us and it's purely a superset of the existing design.

* Telnet-style reporter option that can write to a Socket or a Writer
* Per-metric tag support
* Enable or disable appending of '.count' and '.value' to Counters and Gauges
* Tests for the above
* Fixed JavaDoc warnings