### PR TITLE
Bump dropwizard metrics to version 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <metrics.version>3.1.0</metrics.version>
+        <metrics.version>3.2.0</metrics.version>
         <jersey.version>2.22.2</jersey.version>
         <mockito.version>1.10.17</mockito.version>
         <slf4j.version>1.7.5</slf4j.version>


### PR DESCRIPTION
The change adds the ability to disable certain metric attributes by making use of the newly added constructor parameter `disabledMetricAttributes`.